### PR TITLE
Portability and style changes.

### DIFF
--- a/prune_debug
+++ b/prune_debug
@@ -5,6 +5,7 @@
 # marked for debugging. See Red Hat bugzilla 1285601.
 ######################################################################
 
+PATH=/usr/bin
 EPOCH_DATE=$(date +"%s")
 LOG_FILE="/var/log/grubby_prune_debug"
 

--- a/prune_debug
+++ b/prune_debug
@@ -51,11 +51,9 @@ if [ -f "/etc/grub2-efi.cfg" ]; then
     GRUB_EFI_CFG_BK="${GRUB_EFI_CFG}.${EPOCH_DATE}.rpmsave"
 fi
 
-if [ -z "${GRUB_EFI_CFG}" ]; then
-    if [ -z "${GRUB_CFG}" ]; then
-        display_event "Error" "Could not find a grub configuration to back up"
-        exit_event 0
-    fi
+if [ -z "${GRUB_EFI_CFG}" ] && [ -z "${GRUB_CFG}" ]; then
+    display_event "Error" "Could not find a grub configuration to back up"
+    exit_event 0
 fi
 
 if [ -f "${GRUB_EFI_CFG}" ]; then

--- a/prune_debug
+++ b/prune_debug
@@ -7,7 +7,8 @@
 
 PATH=/usr/bin
 EPOCH_DATE=$(date +"%s")
-LOG_FILE="/var/log/grubby_prune_debug"
+LOG_DIR="/var/log"
+LOG_FILE="${LOG_DIR}/grubby_prune_debug"
 
 display_event()
 {
@@ -24,6 +25,7 @@ exit_event()
     exit $1
 }
 
+[ -d "${LOG_DIR}" ] || mkdir -p -m 0755 "${LOG_DIR}"
 display_event "Start" "Begin search for extraneous debug arguments"
 
 if [ $(id -u) -ne 0 ]; then

--- a/prune_debug
+++ b/prune_debug
@@ -80,14 +80,11 @@ fi
 ######################################################################
 # Remove the systemd.debug kernel arguments from non-debug kernels
 ######################################################################
-for entry_index in $(grubby --info=ALL|grep "^index="| sed 's/^index=//')
-do
+for entry_index in $(grubby --info=ALL|grep "^index="| sed 's/^index=//') ; do
     INDEX_TITLE=$(grubby --info="${entry_index}" 2> /dev/null |grep "^title=" | sed 's/^title=//')
 
     # do not do anything if this was empty
-    if [ -z "${INDEX_TITLE}" ]; then
-        continue
-    fi
+    [ -z "${INDEX_TITLE}" ] && continue
 
     display_event "Examine" "${INDEX_TITLE}"
 
@@ -99,13 +96,13 @@ do
     KERNEL_ARGS=$(grubby --info="${entry_index}" 2> /dev/null |grep "^args=")
 
     if echo "${KERNEL_ARGS}" | grep -q "systemd\.debug"; then
-            if grubby --update-kernel="${entry_index}" --remove-args="systemd.debug"; then
-                    display_event "Update" "Removed debugging arguments for ${INDEX_TITLE}"
-            else
-                    display_event "Error" "grubby failed to remove debug argument from ${INDEX_TITLE}"
-            fi
+        if grubby --update-kernel="${entry_index}" --remove-args="systemd.debug"; then
+            display_event "Update" "Removed debugging arguments for ${INDEX_TITLE}"
+        else
+            display_event "Error" "grubby failed to remove debug argument from ${INDEX_TITLE}"
+        fi
     else
-            display_event "Skip" "No debugging arguments to remove for ${INDEX_TITLE}"
+        display_event "Skip" "No debugging arguments to remove for ${INDEX_TITLE}"
     fi
 done
 

--- a/prune_debug
+++ b/prune_debug
@@ -41,12 +41,12 @@ GRUB_CFG_BK=
 GRUB_EFI_CFG=
 GRUB_EFI_CFG_BK=
 
-if [ -e "/etc/grub2.cfg" ]; then
+if [ -f "/etc/grub2.cfg" ]; then
     GRUB_CFG=$(realpath "/etc/grub2.cfg")
     GRUB_CFG_BK="${GRUB_CFG}.${EPOCH_DATE}.rpmsave"
 fi
 
-if [ -e "/etc/grub2-efi.cfg" ]; then
+if [ -f "/etc/grub2-efi.cfg" ]; then
     GRUB_EFI_CFG=$(realpath "/etc/grub2-efi.cfg")
     GRUB_EFI_CFG_BK="${GRUB_EFI_CFG}.${EPOCH_DATE}.rpmsave"
 fi

--- a/prune_debug
+++ b/prune_debug
@@ -118,12 +118,12 @@ CURRENT_TITLE=$(grubby --info="${CURRENT_DEFAULT_INDEX}" 2> /dev/null |grep "^ti
 CURRENT_KERNEL=$(grubby --info="${CURRENT_DEFAULT_INDEX}" 2> /dev/null |grep "^kernel=" | sed 's/^kernel=//')
 DEFAULT_CHANGED="FALSE"
 if echo "${CURRENT_TITLE}" | grep -q "with debugging$"; then
-    shopt -s nocasematch
-    if [ "${ALLOW_DEBUGGING_DEFAULT}" = "YES" ] || [ "${ALLOW_DEBUGGING_DEFAULT}" = "TRUE" ]; then
-        display_event "Examine" "Detected user preference to allow debugging default entries if present"
-        exit_event 0
-    fi
-    shopt -u nocasematch
+    case "${ALLOW_DEBUGGING_DEFAULT}" in
+        [Yy][Ee][Ss]|[Tt][Rr][Uu][Ee])
+            display_event "Examine" "Detected user preference to allow debugging default entries if present"
+            exit_event 0
+            ;;
+    esac
     display_event "Examine" "Search for entry without debugging to replace default entry - ${CURRENT_TITLE}"
 
     # search for the first non-debugging kernel entry with the same kernel as current

--- a/prune_debug
+++ b/prune_debug
@@ -116,7 +116,7 @@ done
 CURRENT_DEFAULT_INDEX=$(grubby --default-index)
 CURRENT_TITLE=$(grubby --info="${CURRENT_DEFAULT_INDEX}" 2> /dev/null |grep "^title=" | sed 's/^title=//')
 CURRENT_KERNEL=$(grubby --info="${CURRENT_DEFAULT_INDEX}" 2> /dev/null |grep "^kernel=" | sed 's/^kernel=//')
-DEFAULT_CHANGED="FALSE"
+DEFAULT_CHANGED=0
 if echo "${CURRENT_TITLE}" | grep -q "with debugging$"; then
     case "${ALLOW_DEBUGGING_DEFAULT}" in
         [Yy][Ee][Ss]|[Tt][Rr][Uu][Ee])
@@ -147,14 +147,14 @@ if echo "${CURRENT_TITLE}" | grep -q "with debugging$"; then
 
         if grubby --set-default-index="${entry_index}"; then
             display_event "Update" "Selected ${INDEX_TITLE} as the new default entry"
-            DEFAULT_CHANGED="TRUE"
+            DEFAULT_CHANGED=1
             break
         else
             display_event "Error" "Could not set ${INDEX_TITLE} as default, continuing search"
         fi
     done
 
-    if [ "${DEFAULT_CHANGED}" = "FALSE" ]; then
+    if [ ${DEFAULT_CHANGED} -eq 0 ]; then
         display_event "Error" "Could not find a suitable default entry without debugging"
     fi
 fi

--- a/prune_debug
+++ b/prune_debug
@@ -26,7 +26,7 @@ exit_event()
 
 display_event "Start" "Begin search for extraneous debug arguments"
 
-if [[ $EUID -ne 0 ]]; then
+if [ $(id -u) -ne 0 ]; then
     display_event "Error" "This script may only run as root."
     exit_event 0
 fi


### PR DESCRIPTION
Just some portability and style cleanups.  It looks fine otherwise.  I am always nervous with scripts that do a lot of redirecting of stderr, but if you know there is nothing there that needs tracking, it should be fine.

You wrote the script with bashisms, but then put #!/bin/sh at the top.  I am a fan of using non-bash-specific stuff because there are systems (e.g., Debian and mine) where /bin/sh is not bash.  Some people also swap out /bin/sh for something else, especially given Shellshock.

Scan through these, ask questions, take or toss them.  I'll look at the other branch soon.